### PR TITLE
If resource doesn't exist in Datadog it is recreated.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,1 @@
+require: rubocop-rspec

--- a/Gemfile
+++ b/Gemfile
@@ -9,4 +9,5 @@ group :development, :test do
   gem 'guard-rspec'
   gem 'rspec'
   gem 'rubocop'
+  gem 'rubocop-rspec'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,9 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.4.0)
       parser (>= 2.7.1.5)
+    rubocop-rspec (2.1.0)
+      rubocop (~> 1.0)
+      rubocop-ast (>= 1.1.0)
     ruby-progressbar (1.11.0)
     shellany (0.0.1)
     thor (1.0.1)
@@ -102,6 +105,7 @@ DEPENDENCIES
   pry
   rspec
   rubocop
+  rubocop-rspec
 
 BUNDLED WITH
    2.1.4

--- a/bin/datadog_backup
+++ b/bin/datadog_backup
@@ -55,7 +55,10 @@ def prereqs
     opts.on('--dashboards-only') do
       @options[:resources] = [DatadogBackup::Dashboards]
     end
-    opts.on('--json', 'format backups as JSON instead of YAML. Does not impact `diffs` nor `restore`, but do not mix formats in the same backup-dir.') do
+    opts.on(
+      '--json',
+      'format backups as JSON instead of YAML. Does not impact `diffs` nor `restore`, but do not mix formats in the same backup-dir.'
+    ) do
       @options[:output_format] = :json
     end
     opts.on('--no-color', 'removes colored output from diff format') do

--- a/lib/datadog_backup/cli.rb
+++ b/lib/datadog_backup/cli.rb
@@ -109,7 +109,7 @@ module DatadogBackup
         next unless diff
 
         if @options[:force_restore]
-          definitive_resource_instance(id).update(id, definitive_resource_instance(id).load_from_file_by_id(id))
+          definitive_resource_instance(id).restore(id)
         else
           puts '--------------------------------------------------------------------------------'
           puts format_diff_output([id, diff])
@@ -120,7 +120,7 @@ module DatadogBackup
             exit
           when 'r'
             puts "Restoring #{id} to Datadog."
-            definitive_resource_instance(id).update(id, definitive_resource_instance(id).load_from_file_by_id(id))
+            definitive_resource_instance(id).restore(id)
           when 'd'
             puts "Downloading #{id} from Datadog."
             definitive_resource_instance(id).get_and_write_file(id)

--- a/lib/datadog_backup/monitors.rb
+++ b/lib/datadog_backup/monitors.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module DatadogBackup
-  class Monitors < Core    
+  class Monitors < Core
     def all_monitors
       @all_monitors ||= get_all
     end

--- a/spec/datadog_backup/cli_spec.rb
+++ b/spec/datadog_backup/cli_spec.rb
@@ -19,10 +19,10 @@ describe DatadogBackup::Cli do
       resources: [DatadogBackup::Dashboards]
     }
   end
-  let(:cli) { DatadogBackup::Cli.new(options) }
+  let(:cli) { described_class.new(options) }
   let(:dashboards) { DatadogBackup::Dashboards.new(options) }
 
-  before(:example) do
+  before do
     allow(cli).to receive(:resource_instances).and_return([dashboards])
   end
 
@@ -39,15 +39,28 @@ describe DatadogBackup::Cli do
           }
         ]
       end
-      before(:example) do
+
+      before do
         dashboards.write_file('{"text": "diff"}', "#{tempdir}/dashboards/stillthere.json")
         dashboards.write_file('{"text": "diff"}', "#{tempdir}/dashboards/alsostillthere.json")
         dashboards.write_file('{"text": "diff"}', "#{tempdir}/dashboards/deleted.json")
 
         allow(client_double).to receive(:instance_variable_get).with(:@dashboard_service).and_return(api_service_double)
-        allow(api_service_double).to receive(:request).with(Net::HTTP::Get, "/api/v1/dashboard", nil, nil, false).and_return(all_boards)
-        allow(api_service_double).to receive(:request).with(Net::HTTP::Get, "/api/v1/dashboard/stillthere", nil, nil, false).and_return(['200', {}])
-        allow(api_service_double).to receive(:request).with(Net::HTTP::Get, "/api/v1/dashboard/alsostillthere", nil, nil, false).and_return(['200', {}])
+        allow(api_service_double).to receive(:request).with(Net::HTTP::Get,
+                                                            '/api/v1/dashboard',
+                                                            nil,
+                                                            nil,
+                                                            false).and_return(all_boards)
+        allow(api_service_double).to receive(:request).with(Net::HTTP::Get,
+                                                            '/api/v1/dashboard/stillthere',
+                                                            nil,
+                                                            nil,
+                                                            false).and_return(['200', {}])
+        allow(api_service_double).to receive(:request).with(Net::HTTP::Get,
+                                                            '/api/v1/dashboard/alsostillthere',
+                                                            nil,
+                                                            nil,
+                                                            false).and_return(['200', {}])
       end
 
       it 'deletes the file locally as well' do
@@ -58,16 +71,18 @@ describe DatadogBackup::Cli do
   end
 
   describe '#diffs' do
-    before(:example) do
+    subject { cli.diffs }
+
+    before do
       dashboards.write_file('{"text": "diff"}', "#{tempdir}/dashboards/diffs1.json")
       dashboards.write_file('{"text": "diff"}', "#{tempdir}/dashboards/diffs2.json")
       dashboards.write_file('{"text": "diff"}', "#{tempdir}/dashboards/diffs3.json")
       allow(dashboards).to receive(:get_by_id).and_return({ 'text' => 'diff2' })
       allow(cli).to receive(:initialize_client).and_return(client_double)
     end
-    subject { cli.diffs }
+
     it {
-      is_expected.to include(
+      expect(subject).to include(
         " ---\n id: diffs1\n ---\n-text: diff2\n+text: diff\n",
         " ---\n id: diffs3\n ---\n-text: diff2\n+text: diff\n",
         " ---\n id: diffs2\n ---\n-text: diff2\n+text: diff\n"
@@ -76,13 +91,13 @@ describe DatadogBackup::Cli do
   end
 
   describe '#restore' do
-    before(:example) do
+    subject { cli.restore }
+
+    before do
       dashboards.write_file('{"text": "diff"}', "#{tempdir}/dashboards/diffs1.json")
       allow(dashboards).to receive(:get_by_id).and_return({ 'text' => 'diff2' })
       allow(cli).to receive(:initialize_client).and_return(client_double)
     end
-
-    subject { cli.restore }
 
     example 'starts interactive restore' do
       allow($stdin).to receive(:gets).and_return('q')
@@ -98,21 +113,24 @@ describe DatadogBackup::Cli do
       expect(dashboards).to receive(:update).with('diffs1', { 'text' => 'diff' })
       subject
     end
+
     example 'download' do
       allow($stdin).to receive(:gets).and_return('d')
       expect(dashboards).to receive(:write_file).with(%({\n  "text": "diff2"\n}), "#{tempdir}/dashboards/diffs1.json")
       subject
     end
+
     example 'skip' do
       allow($stdin).to receive(:gets).and_return('s')
-      expect(dashboards).to_not receive(:write_file)
-      expect(dashboards).to_not receive(:update)
+      expect(dashboards).not_to receive(:write_file)
+      expect(dashboards).not_to receive(:update)
       subject
     end
+
     example 'quit' do
       allow($stdin).to receive(:gets).and_return('q')
-      expect(dashboards).to_not receive(:write_file)
-      expect(dashboards).to_not receive(:update)
+      expect(dashboards).not_to receive(:write_file)
+      expect(dashboards).not_to receive(:update)
       expect { subject }.to raise_error(SystemExit)
     end
   end

--- a/spec/datadog_backup/core_spec.rb
+++ b/spec/datadog_backup/core_spec.rb
@@ -7,7 +7,7 @@ describe DatadogBackup::Core do
   let(:client_double) { double }
   let(:tempdir) { Dir.mktmpdir }
   let(:core) do
-    DatadogBackup::Core.new(
+    described_class.new(
       action: 'backup',
       api_service: api_service_double,
       client: client_double,
@@ -21,18 +21,19 @@ describe DatadogBackup::Core do
 
   describe '#client' do
     subject { core.client }
+
     it { is_expected.to eq client_double }
   end
 
   describe '#with_200' do
     context 'with 200' do
-      subject { core.with_200 {['200', { foo: :bar }]} }
+      subject { core.with_200 { ['200', { foo: :bar }] } }
 
       it { is_expected.to eq({ foo: :bar }) }
     end
 
     context 'with not 200' do
-      subject { core.with_200 {['400', "Error message"]} }
+      subject { core.with_200 { ['400', 'Error message'] } }
 
       it 'raises an error' do
         expect { subject }.to raise_error(RuntimeError)
@@ -41,14 +42,15 @@ describe DatadogBackup::Core do
   end
 
   describe '#diff' do
-    before(:example) do
+    subject { core.diff('diff') }
+
+    before do
       allow(core).to receive(:get_by_id).and_return({ 'text' => 'diff1', 'extra' => 'diff1' })
       core.write_file('{"text": "diff2", "extra": "diff2"}', "#{tempdir}/core/diff.json")
     end
 
-    subject { core.diff('diff') }
     it {
-      is_expected.to eq <<~EOF
+      expect(subject).to eq <<~EOF
          ---
         -extra: diff1
         -text: diff1
@@ -60,11 +62,13 @@ describe DatadogBackup::Core do
 
   describe '#except' do
     subject { core.except({ a: :b, b: :c }) }
+
     it { is_expected.to eq({ a: :b, b: :c }) }
   end
 
   describe '#initialize' do
     subject { core }
+
     it 'makes the subdirectories' do
       expect(FileUtils).to receive(:mkdir_p).with("#{tempdir}/core")
       subject
@@ -73,18 +77,93 @@ describe DatadogBackup::Core do
 
   describe '#myclass' do
     subject { core.myclass }
+
     it { is_expected.to eq 'core' }
   end
 
-  describe '#update' do
-    subject { core.update('abc-123-def', '{"a": "b"}') }
+  describe '#create' do
+    subject { core.create({ 'a' => 'b' }) }
+
     example 'it calls Dogapi::APIService.request' do
       stub_const('Dogapi::APIService::API_VERSION', 'v1')
       allow(core).to receive(:api_service).and_return(api_service_double)
       allow(core).to receive(:api_version).and_return('v1')
       allow(core).to receive(:api_resource_name).and_return('dashboard')
-      expect(api_service_double).to receive(:request).with(Net::HTTP::Put, '/api/v1/dashboard/abc-123-def', nil, '{"a": "b"}', true).and_return(%w[200 Created])
+      expect(api_service_double).to receive(:request).with(Net::HTTP::Post,
+                                                           '/api/v1/dashboard',
+                                                           nil,
+                                                           { 'a' => 'b' },
+                                                           true).and_return(['200', { 'id' => 'whatever-id-abc' }])
       subject
+    end
+  end
+
+  describe '#update' do
+    subject { core.update('abc-123-def', { 'a' => 'b' }) }
+
+    example 'it calls Dogapi::APIService.request' do
+      stub_const('Dogapi::APIService::API_VERSION', 'v1')
+      allow(core).to receive(:api_service).and_return(api_service_double)
+      allow(core).to receive(:api_version).and_return('v1')
+      allow(core).to receive(:api_resource_name).and_return('dashboard')
+      expect(api_service_double).to receive(:request).with(Net::HTTP::Put,
+                                                           '/api/v1/dashboard/abc-123-def',
+                                                           nil,
+                                                           { 'a' => 'b' },
+                                                           true).and_return(['200', { 'id' => 'whatever-id-abc' }])
+      subject
+    end
+  end
+
+  describe '#restore' do
+    before do
+      allow(core).to receive(:api_service).and_return(api_service_double)
+      allow(core).to receive(:api_version).and_return('api-version-string')
+      allow(core).to receive(:api_resource_name).and_return('api-resource-name-string')
+      allow(api_service_double).to receive(:request).with(Net::HTTP::Get,
+                                                          '/api/api-version-string/api-resource-name-string/abc-123-def',
+                                                          nil,
+                                                          nil,
+                                                          false).and_return(['200', { test: :ok }])
+      allow(api_service_double).to receive(:request).with(Net::HTTP::Get,
+                                                          '/api/api-version-string/api-resource-name-string/bad-123-id',
+                                                          nil,
+                                                          nil,
+                                                          false).and_return(['404', { error: :blahblah_not_found }])
+      allow(core).to receive(:load_from_file_by_id).and_return({ 'load' => 'ok' })
+    end
+
+    context 'when id exists' do
+      subject { core.restore('abc-123-def') }
+
+      example 'it calls out to update' do
+        expect(core).to receive(:update).with('abc-123-def', { 'load' => 'ok' })
+        subject
+      end
+    end
+
+    context 'when id does not exist' do
+      subject { core.restore('bad-123-id') }
+
+      before do
+        allow(api_service_double).to receive(:request).with(Net::HTTP::Put,
+                                                            '/api/api-version-string/api-resource-name-string/bad-123-id',
+                                                            nil, { 'load' => 'ok' },
+                                                            true).and_return(['404', { 'Error' => 'my not found' }])
+        allow(api_service_double).to receive(:request).with(Net::HTTP::Post,
+                                                            '/api/api-version-string/api-resource-name-string',
+                                                            nil,
+                                                            { 'load' => 'ok' },
+                                                            true).and_return(['200', { 'id' => 'my-new-id' }])
+      end
+
+      example 'it calls out to create then saves the new file and deletes the new file' do
+        expect(core).to receive(:create).with({ 'load' => 'ok' }).and_return({ 'id' => 'my-new-id' })
+        expect(core).to receive(:get_and_write_file).with('my-new-id')
+        allow(core).to receive(:find_file_by_id).with('bad-123-id').and_return('/path/to/bad-123-id.json')
+        expect(FileUtils).to receive(:rm).with('/path/to/bad-123-id.json')
+        subject
+      end
     end
   end
 end

--- a/spec/datadog_backup/dashboards_spec.rb
+++ b/spec/datadog_backup/dashboards_spec.rb
@@ -7,7 +7,7 @@ describe DatadogBackup::Dashboards do
   let(:client_double) { double }
   let(:tempdir) { Dir.mktmpdir }
   let(:dashboards) do
-    DatadogBackup::Dashboards.new(
+    described_class.new(
       action: 'backup',
       client: client_double,
       backup_dir: tempdir,
@@ -59,10 +59,13 @@ describe DatadogBackup::Dashboards do
       'title' => 'example dashboard'
     }
   end
-  before(:example) do
+
+  before do
     allow(client_double).to receive(:instance_variable_get).with(:@dashboard_service).and_return(api_service_double)
-    allow(api_service_double).to receive(:request).with(Net::HTTP::Get, "/api/v1/dashboard", nil, nil, false).and_return(all_boards)
-    allow(api_service_double).to receive(:request).with(Net::HTTP::Get, "/api/v1/dashboard/abc-123-def", nil, nil, false).and_return(example_dashboard)
+    allow(api_service_double).to receive(:request).with(Net::HTTP::Get, '/api/v1/dashboard', nil, nil,
+                                                        false).and_return(all_boards)
+    allow(api_service_double).to receive(:request).with(Net::HTTP::Get, '/api/v1/dashboard/abc-123-def', nil, nil,
+                                                        false).and_return(example_dashboard)
   end
 
   describe '#backup' do
@@ -100,17 +103,19 @@ describe DatadogBackup::Dashboards do
         -title: example dashboard
         +a: b
       EOF
-    )
+                                                  )
     end
   end
 
   describe '#except' do
     subject { dashboards.except({ :a => :b, 'modified_at' => :c, 'url' => :d }) }
+
     it { is_expected.to eq({ a: :b }) }
   end
 
   describe '#get_by_id' do
     subject { dashboards.get_by_id('abc-123-def') }
+
     it { is_expected.to eq board_abc_123_def }
   end
 end

--- a/spec/datadog_backup/local_filesystem_spec.rb
+++ b/spec/datadog_backup/local_filesystem_spec.rb
@@ -27,55 +27,61 @@ describe DatadogBackup::LocalFilesystem do
   end
 
   describe '#all_files' do
-    before(:example) do
+    subject { core.all_files }
+
+    before do
       File.new("#{tempdir}/all_files.json", 'w')
     end
 
-    after(:example) do
+    after do
       FileUtils.rm "#{tempdir}/all_files.json"
     end
 
-    subject { core.all_files }
     it { is_expected.to eq(["#{tempdir}/all_files.json"]) }
   end
 
   describe '#all_file_ids_for_selected_resources' do
-    before(:example) do
+    subject { core.all_file_ids_for_selected_resources }
+
+    before do
       Dir.mkdir("#{tempdir}/dashboards")
       Dir.mkdir("#{tempdir}/monitors")
       File.new("#{tempdir}/dashboards/all_files.json", 'w')
       File.new("#{tempdir}/monitors/12345.json", 'w')
     end
 
-    after(:example) do
+    after do
       FileUtils.rm "#{tempdir}/dashboards/all_files.json"
       FileUtils.rm "#{tempdir}/monitors/12345.json"
     end
 
-    subject { core.all_file_ids_for_selected_resources }
     it { is_expected.to eq(['all_files']) }
   end
 
   describe '#class_from_id' do
-    before(:example) do
+    subject { core.class_from_id('abc-123-def') }
+
+    before do
       core.write_file('abc', "#{tempdir}/core/abc-123-def.json")
     end
 
-    after(:example) do
+    after do
       FileUtils.rm "#{tempdir}/core/abc-123-def.json"
     end
-    subject { core.class_from_id('abc-123-def') }
+
     it { is_expected.to eq DatadogBackup::Core }
   end
 
   describe '#dump' do
     context ':json' do
       subject { core.dump({ a: :b }) }
+
       it { is_expected.to eq(%({\n  "a": "b"\n})) }
     end
 
     context ':yaml' do
       subject { core_yaml.dump({ 'a' => 'b' }) }
+
       it { is_expected.to eq(%(---\na: b\n)) }
     end
   end
@@ -83,80 +89,94 @@ describe DatadogBackup::LocalFilesystem do
   describe '#filename' do
     context ':json' do
       subject { core.filename('abc-123-def') }
+
       it { is_expected.to eq("#{tempdir}/core/abc-123-def.json") }
     end
 
     context ':yaml' do
       subject { core_yaml.filename('abc-123-def') }
+
       it { is_expected.to eq("#{tempdir}/core/abc-123-def.yaml") }
     end
   end
 
   describe '#file_type' do
-    before(:example) do
+    subject { core.file_type("#{tempdir}/file_type.json") }
+
+    before do
       File.new("#{tempdir}/file_type.json", 'w')
     end
 
-    after(:example) do
+    after do
       FileUtils.rm "#{tempdir}/file_type.json"
     end
 
-    subject { core.file_type("#{tempdir}/file_type.json") }
     it { is_expected.to eq :json }
   end
 
   describe '#find_file_by_id' do
-    before(:example) do
+    subject { core.find_file_by_id('find_file') }
+
+    before do
       File.new("#{tempdir}/find_file.json", 'w')
     end
 
-    after(:example) do
+    after do
       FileUtils.rm "#{tempdir}/find_file.json"
     end
 
-    subject { core.find_file_by_id('find_file') }
     it { is_expected.to eq "#{tempdir}/find_file.json" }
   end
 
   describe '#load_from_file' do
     context ':json' do
       subject { core.load_from_file(%({\n  "a": "b"\n}), :json) }
+
       it { is_expected.to eq('a' => 'b') }
     end
 
     context ':yaml' do
       subject { core.load_from_file(%(---\na: b\n), :yaml) }
+
       it { is_expected.to eq('a' => 'b') }
     end
   end
 
   describe '#load_from_file_by_id' do
     context 'written in json read in yaml mode' do
-      before(:example) { core.write_file(%({"a": "b"}), "#{tempdir}/core/abc-123-def.json") }
-      after(:example) { FileUtils.rm "#{tempdir}/core/abc-123-def.json" }
-
       subject { core_yaml.load_from_file_by_id('abc-123-def') }
+
+      before { core.write_file(%({"a": "b"}), "#{tempdir}/core/abc-123-def.json") }
+
+      after { FileUtils.rm "#{tempdir}/core/abc-123-def.json" }
+
       it { is_expected.to eq('a' => 'b') }
     end
-    context 'written in yaml read in json mode' do
-      before(:example) { core.write_file(%(---\na: b), "#{tempdir}/core/abc-123-def.yaml") }
-      after(:example) { FileUtils.rm "#{tempdir}/core/abc-123-def.yaml" }
 
+    context 'written in yaml read in json mode' do
       subject { core.load_from_file_by_id('abc-123-def') }
+
+      before { core.write_file(%(---\na: b), "#{tempdir}/core/abc-123-def.yaml") }
+
+      after { FileUtils.rm "#{tempdir}/core/abc-123-def.yaml" }
+
       it { is_expected.to eq('a' => 'b') }
     end
 
     context 'Integer as parameter' do
-      before(:example) { core.write_file(%(---\na: b), "#{tempdir}/core/12345.yaml") }
-      after(:example) { FileUtils.rm "#{tempdir}/core/12345.yaml" }
-
       subject { core.load_from_file_by_id(12_345) }
+
+      before { core.write_file(%(---\na: b), "#{tempdir}/core/12345.yaml") }
+
+      after { FileUtils.rm "#{tempdir}/core/12345.yaml" }
+
       it { is_expected.to eq('a' => 'b') }
     end
   end
 
   describe '#write_file' do
     subject { core.write_file('abc123', "#{tempdir}/core/abc-123-def.json") }
+
     let(:file_like_object) { double }
 
     it 'writes a file to abc-123-def.json' do

--- a/spec/datadog_backup/monitors_spec.rb
+++ b/spec/datadog_backup/monitors_spec.rb
@@ -7,7 +7,7 @@ describe DatadogBackup::Monitors do
   let(:client_double) { double }
   let(:tempdir) { Dir.mktmpdir }
   let(:monitors) do
-    DatadogBackup::Monitors.new(
+    described_class.new(
       action: 'backup',
       client: client_double,
       backup_dir: tempdir,
@@ -49,14 +49,17 @@ describe DatadogBackup::Monitors do
     ]
   end
 
-  before(:example) do
+  before do
     allow(client_double).to receive(:instance_variable_get).with(:@monitor_svc).and_return(api_service_double)
-    allow(api_service_double).to receive(:request).with(Net::HTTP::Get, "/api/v1/monitor", nil, nil, false).and_return(all_monitors)
-    allow(api_service_double).to receive(:request).with(Net::HTTP::Get, "/api/v1/dashboard/123455", nil, nil, false).and_return(example_monitor)
+    allow(api_service_double).to receive(:request).with(Net::HTTP::Get, '/api/v1/monitor', nil, nil,
+                                                        false).and_return(all_monitors)
+    allow(api_service_double).to receive(:request).with(Net::HTTP::Get, '/api/v1/dashboard/123455', nil, nil,
+                                                        false).and_return(example_monitor)
   end
 
   describe '#all_monitors' do
     subject { monitors.all_monitors }
+
     it { is_expected.to eq [monitor_description] }
   end
 
@@ -100,16 +103,20 @@ describe DatadogBackup::Monitors do
 
   describe '#filename' do
     subject { monitors.filename(123_455) }
+
     it { is_expected.to eq("#{tempdir}/monitors/123455.json") }
   end
 
   describe '#get_by_id' do
     context 'Integer' do
       subject { monitors.get_by_id(123_455) }
+
       it { is_expected.to eq monitor_description }
     end
+
     context 'String' do
       subject { monitors.get_by_id('123455') }
+
       it { is_expected.to eq monitor_description }
     end
   end

--- a/spec/datadog_backup_bin_spec.rb
+++ b/spec/datadog_backup_bin_spec.rb
@@ -47,7 +47,7 @@ describe 'bin/datadog_backup' do
     it "dies unless given ENV[#{v}]" do
       ClimateControl.env[v] = nil
       _, status = run_bin('backup')
-      expect(status).to_not be_success
+      expect(status).not_to be_success
     end
   end
 


### PR DESCRIPTION
The PR introduces the following changes:
- `datadog-backup` used to exit with an error if a resource wasn't found in Datadog, now it is recreated