### PR TITLE
fix: remove max queue size limit

### DIFF
--- a/lib/datadog_backup/thread_pool.rb
+++ b/lib/datadog_backup/thread_pool.rb
@@ -5,7 +5,6 @@ module DatadogBackup
     TPOOL = ::Concurrent::ThreadPoolExecutor.new(
       min_threads: [2, Concurrent.processor_count].max,
       max_threads: [2, Concurrent.processor_count].max * 2,
-      max_queue: [2, Concurrent.processor_count].max * 512,
       fallback_policy: :abort
     )
 


### PR DESCRIPTION
When there are not a lot of CPU cores (like in CI), then the limit for number of elements in the queue are too low, resulting in this error: 

```
[jimp@ip-172-31-88-180 scribd-datadog-backups]$ bundle exec datadog_backup restore
I, [2021-07-08T16:20:56.427354 #30222]  INFO -- : Starting diffs on 4 threads
Traceback (most recent call last):
	26: from /home/jimp/.rvm/gems/ruby-2.7.3@scribd-datadog-backups/bin/ruby_executable_hooks:22:in `<main>'
	25: from /home/jimp/.rvm/gems/ruby-2.7.3@scribd-datadog-backups/bin/ruby_executable_hooks:22:in `eval'
	24: from /home/jimp/.rvm/gems/ruby-2.7.3@scribd-datadog-backups/bin/datadog_backup:23:in `<main>'
	23: from /home/jimp/.rvm/gems/ruby-2.7.3@scribd-datadog-backups/bin/datadog_backup:23:in `load'
	22: from /home/jimp/.rvm/gems/ruby-2.7.3@scribd-datadog-backups/gems/datadog_backup-1.0.3/bin/datadog_backup:86:in `<top (required)>'
	21: from /home/jimp/.rvm/gems/ruby-2.7.3@scribd-datadog-backups/gems/datadog_backup-1.0.3/lib/datadog_backup/cli.rb:139:in `run!'
	20: from /home/jimp/.rvm/gems/ruby-2.7.3@scribd-datadog-backups/gems/datadog_backup-1.0.3/lib/datadog_backup/cli.rb:104:in `restore'
	19: from /home/jimp/.rvm/gems/ruby-2.7.3@scribd-datadog-backups/gems/datadog_backup-1.0.3/lib/datadog_backup/cli.rb:15:in `all_diff_futures'
	18: from /home/jimp/.rvm/gems/ruby-2.7.3@scribd-datadog-backups/gems/datadog_backup-1.0.3/lib/datadog_backup/cli.rb:15:in `map'
	17: from /home/jimp/.rvm/gems/ruby-2.7.3@scribd-datadog-backups/gems/datadog_backup-1.0.3/lib/datadog_backup/cli.rb:16:in `block in all_diff_futures'
	16: from /home/jimp/.rvm/gems/ruby-2.7.3@scribd-datadog-backups/gems/concurrent-ruby-1.1.9/lib/concurrent-ruby/concurrent/promises.rb:105:in `future_on'
	15: from /home/jimp/.rvm/gems/ruby-2.7.3@scribd-datadog-backups/gems/concurrent-ruby-1.1.9/lib/concurrent-ruby/concurrent/promises.rb:595:in `chain'
	14: from /home/jimp/.rvm/gems/ruby-2.7.3@scribd-datadog-backups/gems/concurrent-ruby-1.1.9/lib/concurrent-ruby/concurrent/promises.rb:613:in `chain_on'
	13: from /home/jimp/.rvm/gems/ruby-2.7.3@scribd-datadog-backups/gems/concurrent-ruby-1.1.9/lib/concurrent-ruby/concurrent/promises.rb:1615:in `new_blocked_by1'
	12: from /home/jimp/.rvm/gems/ruby-2.7.3@scribd-datadog-backups/gems/concurrent-ruby-1.1.9/lib/concurrent-ruby/concurrent/promises.rb:732:in `add_callback_notify_blocked'
	11: from /home/jimp/.rvm/gems/ruby-2.7.3@scribd-datadog-backups/gems/concurrent-ruby-1.1.9/lib/concurrent-ruby/concurrent/promises.rb:751:in `add_callback'
	10: from /home/jimp/.rvm/gems/ruby-2.7.3@scribd-datadog-backups/gems/concurrent-ruby-1.1.9/lib/concurrent-ruby/concurrent/promises.rb:786:in `call_callback'
	 9: from /home/jimp/.rvm/gems/ruby-2.7.3@scribd-datadog-backups/gems/concurrent-ruby-1.1.9/lib/concurrent-ruby/concurrent/promises.rb:808:in `callback_notify_blocked'
	 8: from /home/jimp/.rvm/gems/ruby-2.7.3@scribd-datadog-backups/gems/concurrent-ruby-1.1.9/lib/concurrent-ruby/concurrent/promises.rb:1660:in `on_blocker_resolution'
	 7: from /home/jimp/.rvm/gems/ruby-2.7.3@scribd-datadog-backups/gems/concurrent-ruby-1.1.9/lib/concurrent-ruby/concurrent/promises.rb:1764:in `on_resolvable'
	 6: from /home/jimp/.rvm/gems/ruby-2.7.3@scribd-datadog-backups/gems/concurrent-ruby-1.1.9/lib/concurrent-ruby/concurrent/executor/ruby_executor_service.rb:19:in `post'
	 5: from /home/jimp/.rvm/gems/ruby-2.7.3@scribd-datadog-backups/gems/concurrent-ruby-1.1.9/lib/concurrent-ruby/concurrent/synchronization/mutex_lockable_object.rb:47:in `synchronize'
	 4: from /home/jimp/.rvm/gems/ruby-2.7.3@scribd-datadog-backups/gems/concurrent-ruby-1.1.9/lib/concurrent-ruby/concurrent/synchronization/mutex_lockable_object.rb:47:in `synchronize'
	 3: from /home/jimp/.rvm/gems/ruby-2.7.3@scribd-datadog-backups/gems/concurrent-ruby-1.1.9/lib/concurrent-ruby/concurrent/synchronization/mutex_lockable_object.rb:47:in `block in synchronize'
	 2: from /home/jimp/.rvm/gems/ruby-2.7.3@scribd-datadog-backups/gems/concurrent-ruby-1.1.9/lib/concurrent-ruby/concurrent/executor/ruby_executor_service.rb:22:in `block in post'
	 1: from /home/jimp/.rvm/gems/ruby-2.7.3@scribd-datadog-backups/gems/concurrent-ruby-1.1.9/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:159:in `ns_execute'
/home/jimp/.rvm/gems/ruby-2.7.3@scribd-datadog-backups/gems/concurrent-ruby-1.1.9/lib/concurrent-ruby/concurrent/executor/abstract_executor_service.rb:87:in `handle_fallback': Concurrent::RejectedExecutionError (Concurrent::RejectedExecutionError)
[jimp@ip-172-31-88-180 scribd-datadog-backups]$
```