### PR TITLE
doc: Update ruby setup action so it works for 2.7.1

### DIFF
--- a/example/.github/workflows/backup.yml
+++ b/example/.github/workflows/backup.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby 2.7.1
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7.1
     - name: perform backup


### PR DESCRIPTION
I tried to set up this action as it exists, but I got setup issues saying ruby version 2.7.1 was not available. Following a few google leads I found that the project is now ruby/setup-ruby.