### PR TITLE
fix: include version.rb in release commit

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -18,7 +18,8 @@ module.exports = {
       "@semantic-release/git",
       {
         "assets": [
-          "CHANGELOG.md"
+          "CHANGELOG.md",
+          "lib/datadog_backup/version.rb"
         ],
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }


### PR DESCRIPTION
Previous releases did not update version.rb