### PR TITLE
fix: Deprecate Ruby 2.6 and Drop support for Ruby 2.5

### DIFF
--- a/.github/workflows/rspec_and_release.yml
+++ b/.github/workflows/rspec_and_release.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-        ruby: [2.5, 2.6, 2.7, '3.0', '3.1']
+        ruby: [2.6, 2.7, '3.0', '3.1']
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/rspec_and_release.yml
+++ b/.github/workflows/rspec_and_release.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-        ruby: [2.7, '3.0', '3.1']
+        ruby: [2.5, 2.6, 2.7, '3.0', '3.1']
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,11 +2,11 @@ PATH
   remote: .
   specs:
     datadog_backup (2.0.1)
-      amazing_print (= 1.4.0)
-      concurrent-ruby (= 1.1.10)
-      deepsort (= 0.4.5)
-      diffy (= 3.4.2)
-      dogapi (= 1.45.0)
+      amazing_print (~> 1.4.0)
+      concurrent-ruby (~> 1.1.10)
+      deepsort (~> 0.4.5)
+      diffy (~> 3.4.2)
+      dogapi (~> 1.45.0)
 
 GEM
   remote: https://rubygems.org/

--- a/datadog_backup.gemspec
+++ b/datadog_backup.gemspec
@@ -19,13 +19,13 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^spec/})
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = ['>= 2.5']
+  spec.required_ruby_version = ['>= 2.6']
 
-  spec.add_dependency 'amazing_print', '1.4.0'
-  spec.add_dependency 'concurrent-ruby', '1.1.10'
-  spec.add_dependency 'deepsort', '0.4.5'
-  spec.add_dependency 'diffy', '3.4.2'
-  spec.add_dependency 'dogapi', '1.45.0'
+  spec.add_dependency 'amazing_print', '~> 1.4.0'
+  spec.add_dependency 'concurrent-ruby', '~> 1.1.10'
+  spec.add_dependency 'deepsort', '~> 0.4.5'
+  spec.add_dependency 'diffy', '~> 3.4.2'
+  spec.add_dependency 'dogapi', '~> 1.45.0'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'pry'

--- a/lib/datadog_backup.rb
+++ b/lib/datadog_backup.rb
@@ -6,13 +6,16 @@ require 'dogapi'
 
 require_relative 'datadog_backup/local_filesystem'
 require_relative 'datadog_backup/options'
-
 require_relative 'datadog_backup/cli'
 require_relative 'datadog_backup/core'
 require_relative 'datadog_backup/dashboards'
 require_relative 'datadog_backup/monitors'
 require_relative 'datadog_backup/thread_pool'
 require_relative 'datadog_backup/version'
+require_relative 'datadog_backup/deprecations'
+DatadogBackup::Deprecations.check
+
 
 module DatadogBackup
 end
+

--- a/lib/datadog_backup/deprecations.rb
+++ b/lib/datadog_backup/deprecations.rb
@@ -1,0 +1,11 @@
+
+
+module DatadogBackup
+  module Deprecations
+    def self.check
+      if RUBY_VERSION < '2.7'
+        LOGGER.warn "ruby-#{RUBY_VERSION} is deprecated. Ruby 2.7 or higher will be required to use this gem after datadog_backup@v3"
+      end
+    end
+  end
+end

--- a/spec/datadog_backup/deprecations_spec.rb
+++ b/spec/datadog_backup/deprecations_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe DatadogBackup::Deprecations do
+  let(:logger) { double }
+
+  before do
+    stub_const('LOGGER', logger)
+    allow(logger).to receive(:warn)
+  end
+
+  %w[2.4.10 2.5.9 2.6.8].each do |ruby_version|
+    describe "#check#{ruby_version}" do
+      subject { described_class.check }
+
+      it 'does warn' do
+        stub_const('RUBY_VERSION', ruby_version)
+        expect(logger).to receive(:warn).with(/ruby-#{ruby_version} is deprecated./)
+        subject
+      end
+    end
+  end
+
+  %w[2.7.4 3.0.4 3.1.2 3.2.0-preview1].each do |ruby_version|
+    describe "#check#{ruby_version}" do
+      subject { described_class.check }
+
+      it 'does not warn' do
+        stub_const('RUBY_VERSION', ruby_version)
+        expect(logger).to_not receive(:warn).with(/ruby-#{ruby_version} is deprecated./)
+        subject
+      end
+    end
+  end
+end


### PR DESCRIPTION
I'll take a lesson from [terraform AWS provider v4.0](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-4-upgrade) and rather than pull the rug on ruby 2.6, gracefully deprecate ruby 2.6 for datadog_backup v2.

Unfortunately, I was having difficulties with [testing ruby 2.5](https://github.com/scribd/datadog_backup/runs/7778799883?check_suite_focus=true) Given what appears to be [no users in the past 6 months who have downloaded datadog_backup with ruby 2.5](https://ui.honeycomb.io/ruby-together/datasets/rubygems.org/result/td8MFgN16wc), we'll part ways here. 

![image](https://user-images.githubusercontent.com/176915/184068285-a035c2d1-16e1-44f8-8a85-b2f0a99c205d.png)

Please pin to datadog_backup v1 if you are on ruby 2.5. 

Please do let me know if I failed to consider your use case.
