### PR TITLE
feat!: release 3.0

### DIFF
--- a/.github/workflows/rspec_and_release.yml
+++ b/.github/workflows/rspec_and_release.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-        ruby: [2.6, 2.7, '3.0', '3.1']
+        ruby: [2.7, '3.0', '3.1']
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# [3.0.0-alpha.1](https://github.com/scribd/datadog_backup/compare/v2.0.2...v3.0.0-alpha.1) (2022-08-24)
+
+
+* feat!: release 3.0 ([d09d9e6](https://github.com/scribd/datadog_backup/commit/d09d9e6c845edb35c49cbb19ec6b35878304a078))
+
+
+### BREAKING CHANGES
+
+* DATADOG_API_KEY and DATADOG_APP_KEY are no longer the environment variables used to authenticate to Datadog. Instead, set the environment variables DD_API_KEY and DD_APP_KEY.
+* ruby 2.6 is no longer supported. Please upgrade to ruby 2.7 or higher.
+* The options `--ssh` and `--ssshh` are no longer supported. Instead, please use `--quiet` to supress logging. `--debug` remains supported.
+* The environment variable `DATADOG_HOST` is no longer supported. Instead, please use `DD_SITE_URL`.
+
+refactor: The legacy [dogapi-rb ](https://github.com/DataDog/dogapi-rb) gem is replaced with [faraday](https://lostisland.github.io/faraday/).  The [official client library](https://github.com/DataDog/datadog-api-client-ruby) was considered, but was not adopted as I had a hard time grok-ing it.
+
 ## [2.0.2](https://github.com/scribd/datadog_backup/compare/v2.0.1...v2.0.2) (2022-08-11)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [3.0.0-alpha.2](https://github.com/scribd/datadog_backup/compare/v3.0.0-alpha.1...v3.0.0-alpha.2) (2022-08-25)
+
+
+### Bug Fixes
+
+* remove development pry ([611d0a6](https://github.com/scribd/datadog_backup/commit/611d0a6dd5899b0046fc00233cf679834b275089))
+
 # [3.0.0-alpha.1](https://github.com/scribd/datadog_backup/compare/v2.0.2...v3.0.0-alpha.1) (2022-08-24)
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,25 +1,31 @@
 PATH
   remote: .
   specs:
-    datadog_backup (2.0.1)
-      amazing_print (~> 1.4.0)
-      concurrent-ruby (~> 1.1.10)
-      deepsort (~> 0.4.5)
-      diffy (~> 3.4.2)
-      dogapi (~> 1.45.0)
+    datadog_backup (2.0.2)
+      amazing_print
+      concurrent-ruby
+      deepsort
+      diffy
+      faraday
+      faraday-retry
 
 GEM
   remote: https://rubygems.org/
   specs:
     amazing_print (1.4.0)
     ast (2.4.2)
+    byebug (11.1.3)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
     deepsort (0.4.5)
     diff-lcs (1.5.0)
     diffy (3.4.2)
-    dogapi (1.45.0)
-      multi_json
+    faraday (2.5.2)
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
+    faraday-net_http (3.0.0)
+    faraday-retry (2.0.0)
+      faraday (~> 2.0)
     ffi (1.15.5)
     formatador (1.1.0)
     guard (2.18.0)
@@ -42,7 +48,6 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     lumberjack (1.2.8)
     method_source (1.0.0)
-    multi_json (1.15.0)
     nenv (0.3.0)
     notiffany (0.1.3)
       nenv (~> 0.1)
@@ -53,6 +58,9 @@ GEM
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    pry-byebug (3.10.1)
+      byebug (~> 11.0)
+      pry (>= 0.13, < 0.15)
     rainbow (3.1.1)
     rb-fsevent (0.11.1)
     rb-inotify (0.10.1)
@@ -72,14 +80,14 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
     rspec-support (3.11.0)
-    rubocop (1.34.1)
+    rubocop (1.35.1)
       json (~> 2.3)
       parallel (~> 1.10)
       parser (>= 3.1.2.1)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.20.0, < 2.0)
+      rubocop-ast (>= 1.20.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.21.0)
@@ -87,21 +95,24 @@ GEM
     rubocop-rspec (2.12.1)
       rubocop (~> 1.31)
     ruby-progressbar (1.11.0)
+    ruby2_keywords (0.0.5)
     shellany (0.0.1)
     thor (1.2.1)
     unicode-display_width (2.2.0)
 
 PLATFORMS
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   bundler
   datadog_backup!
   guard-rspec
   pry
+  pry-byebug
   rspec
   rubocop
   rubocop-rspec
 
 BUNDLED WITH
-   2.3.19
+   2.3.20

--- a/README.md
+++ b/README.md
@@ -13,12 +13,17 @@ Additional features may be built out over time.
 
 # v3 Migration
 
+## Breaking Changes
 v3 is a backwards incompatible change.
 
 - [] DATADOG_API_KEY and DATADOG_APP_KEY are no longer the environment variables used to authenticate to Datadog. Instead, set the environment variables DD_API_KEY and DD_APP_KEY.
 - [ ] ruby 2.6 is no longer supported. Please upgrade to ruby 2.7 or higher.
 - [ ] The options `--ssh` and `--ssshh` are no longer supported. Instead, please use `--quiet` to supress logging. `--debug` remains supported.
 - [ ] The environment variable `DATADOG_HOST` is no longer supported. Instead, please use `DD_SITE_URL`.
+
+## Misc
+- [ ] The legacy [dogapi-rb ](https://github.com/DataDog/dogapi-rb) gem is replaced with [faraday](https://lostisland.github.io/faraday/).  The [official client library](https://github.com/DataDog/datadog-api-client-ruby) was considered, but was not adopted as I had a hard time grok-ing it.
+
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ Currently supports
 
 Additional features may be built out over time.
 
+# v3 Migration
+
+v3 is a backwards incompatible change.
+
+- [] DATADOG_API_KEY and DATADOG_APP_KEY are no longer the environment variables used to authenticate to Datadog. Instead, set the environment variables DD_API_KEY and DD_APP_KEY.
+- [ ] ruby 2.6 is no longer supported. Please upgrade to ruby 2.7 or higher.
+- [ ] The options `--ssh` and `--ssshh` are no longer supported. Instead, please use `--quiet` to supress logging. `--debug` remains supported.
+- [ ] The environment variable `DATADOG_HOST` is no longer supported. Instead, please use `DD_SITE_URL`.
+
 ## Installation
 
 ```
@@ -22,13 +31,13 @@ gem install datadog_backup
 ![demo](images/demo.gif)
 
 ```
-DATADOG_API_KEY=example123 DATADOG_APP_KEY=example123 datadog_backup <backup|diffs|restore> [--backup-dir /path/to/backups] [--debug] [--monitors-only] [--dashboards-only] [--diff-format color|html|html_simple] [--no-color] [--json]
+DD_API_KEY=example123 DD_APP_KEY=example123 datadog_backup <backup|diffs|restore> [--backup-dir /path/to/backups] [--debug] [--monitors-only] [--dashboards-only] [--diff-format color|html|html_simple] [--no-color] [--json]
 ```
 
 ```
 gem install datadog_backup
-export DATADOG_API_KEY=abc123
-export DATADOG_APP_KEY=abc123
+export DD_API_KEY=abc123
+export DD_APP_KEY=abc123
 
 # Perform backup to `./backup/` using YAML encoding
 datadog_backup backup
@@ -49,8 +58,7 @@ Supply the following parameters in order to customize datadog_backup:
 parameter            | description                                                                                                                   | default
 ---------------------|-------------------------------------------------------------------------------------------------------------------------------|--------------------------
 --debug              | log debug and above                                                                                                           | info
---shh                | log warnings and above                                                                                                        | info
---shhh               | log errors and above                                                                                                          | info
+--quiet              | only show errors and above                                                                                                    | info
 --backup-dir PATH    | path to the directory to backup to or restore from                                                                            | `./backup/`
 --monitors-only      | only backup monitors                                                                                                          | backup monitors and dashboards
 --dashboards-only    | only backup dashboards                                                                                                        | backup monitors and dashboards
@@ -66,10 +74,9 @@ The following environment variables can be set in order to further customize dat
 
 environment variable | description                                                                      | default
 ---------------------|--------------------------------------------------------------------------------|--------------------------
-DATADOG_HOST         | Describe the API endpoint to connect to (https://api.datadoghq.eu for example)   | https://api.datadoghq.com
-http_proxy           | Instruct Dogapi to connect via a differnt proxy address                          | none
-https_proxy          | Same as `http_proxy`                                                             | none
-dd_proxy_https       | Same as `http_proxy`                                                             | none
+DD_SITE_URL          | Describe the API endpoint to connect to (https://api.datadoghq.eu for example)   | https://api.datadoghq.com
+DD_API_KEY           | The API key for the Datadog account                                              | none
+DD_API_KEY           | The Application key for the Datadog account                                      | none
 
 
 ### Usage in a Github repo

--- a/bin/datadog_backup
+++ b/bin/datadog_backup
@@ -10,7 +10,6 @@ LOGGER = Logger.new($stderr) unless defined?(LOGGER)
 LOGGER.level = Logger::INFO
 
 require 'datadog_backup'
-require 'dogapi'
 
 
 def fatal(message)
@@ -19,9 +18,8 @@ def fatal(message)
 end
 
 def options_valid?(options)
-  %w[backup diffs restore].include?(options[:action]) &&
-    options[:datadog_api_key] &&
-    options[:datadog_app_key]
+  %w[backup diffs restore].include?(options[:action])
+  %w[DD_API_KEY DD_APP_KEY].all? { |key| ENV[key] }
 end
 
 def prereqs(defaults)
@@ -30,7 +28,7 @@ def prereqs(defaults)
   result = defaults.dup
 
   options = OptionParser.new do |opts|
-    opts.banner = "Usage: DATADOG_API_KEY=abc123 DATADOG_APP_KEY=abc123 #{File.basename($PROGRAM_NAME)} <backup|diffs|restore>"
+    opts.banner = "Usage: DD_API_KEY=abc123 DD_APP_KEY=abc123 #{File.basename($PROGRAM_NAME)} <backup|diffs|restore>"
     opts.separator ''
     opts.on_tail('-h', '--help', 'Show this message') do
       puts opts
@@ -39,10 +37,7 @@ def prereqs(defaults)
     opts.on('--debug', 'log debug and above') do
       LOGGER.level = Logger::DEBUG
     end
-    opts.on('--shh', 'log warnings and above') do
-      LOGGER.level = Logger::WARN
-    end
-    opts.on('--shhh', 'log errors and above') do
+    opts.on('--quiet', 'log errors and above') do
       LOGGER.level = Logger::ERROR
     end
     opts.on('--backup-dir PATH', '`backup` by default') do |path|
@@ -73,7 +68,7 @@ def prereqs(defaults)
   options.parse!
 
   result[:action] = ARGV.first
-  fatal(options) unless options_valid?(result)
+  fatal(options.banner) unless options_valid?(result)
   result
 end
 
@@ -81,8 +76,6 @@ end
 # Default parameters
 defaults = {
   action: nil,
-  datadog_api_key: ENV.fetch('DATADOG_API_KEY', nil),
-  datadog_app_key: ENV.fetch('DATADOG_APP_KEY', nil),
   backup_dir: File.join(ENV.fetch('PWD'), 'backup'),
   diff_format: :color,
   resources: [DatadogBackup::Dashboards, DatadogBackup::Monitors],
@@ -90,4 +83,9 @@ defaults = {
   force_restore: false
 }
 
+begin
 DatadogBackup::Cli.new(prereqs(defaults)).run!
+rescue => e
+  require 'pry'
+  binding.pry
+end

--- a/datadog_backup.gemspec
+++ b/datadog_backup.gemspec
@@ -19,16 +19,19 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^spec/})
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = ['>= 2.6']
+  spec.required_ruby_version = ['>= 2.7']
 
-  spec.add_dependency 'amazing_print', '~> 1.4.0'
-  spec.add_dependency 'concurrent-ruby', '~> 1.1.10'
-  spec.add_dependency 'deepsort', '~> 0.4.5'
-  spec.add_dependency 'diffy', '~> 3.4.2'
-  spec.add_dependency 'dogapi', '~> 1.45.0'
+  spec.add_dependency 'amazing_print'
+  spec.add_dependency 'concurrent-ruby'
+  spec.add_dependency 'deepsort'
+  spec.add_dependency 'diffy'
+  spec.add_dependency 'faraday'
+  spec.add_dependency 'faraday-retry'
+
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'guard-rspec'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rubocop'

--- a/example/.github/workflows/backup.yml
+++ b/example/.github/workflows/backup.yml
@@ -17,8 +17,8 @@ jobs:
         ruby-version: 2.7.1
     - name: perform backup
       env:
-        DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
-        DATADOG_APP_KEY: ${{ secrets.DATADOG_APP_KEY }}
+        DD_API_KEY: ${{ secrets.DD_API_KEY }}
+        DD_APP_KEY: ${{ secrets.DD_APP_KEY }}
       run: |
           gem install --no-document bundler
           bundle install --jobs 4 --retry 3

--- a/lib/datadog_backup.rb
+++ b/lib/datadog_backup.rb
@@ -2,7 +2,8 @@
 
 require 'concurrent'
 
-require 'dogapi'
+require 'pry' #TODO: remove this
+require 'pry-byebug' #TODO: remove this
 
 require_relative 'datadog_backup/local_filesystem'
 require_relative 'datadog_backup/options'

--- a/lib/datadog_backup/cli.rb
+++ b/lib/datadog_backup/cli.rb
@@ -28,13 +28,6 @@ module DatadogBackup
       any_resource_instance.all_files
     end
 
-    def initialize_client
-      @options[:client] ||= Dogapi::Client.new(
-        datadog_api_key,
-        datadog_app_key
-      )
-    end
-
     def definitive_resource_instance(id)
       matching_resource_instance(any_resource_instance.class_from_id(id))
     end
@@ -86,7 +79,6 @@ module DatadogBackup
 
     def initialize(options)
       @options = options
-      initialize_client
     end
 
     def matching_resource_instance(klass)

--- a/lib/datadog_backup/monitors.rb
+++ b/lib/datadog_backup/monitors.rb
@@ -6,11 +6,6 @@ module DatadogBackup
       @all_monitors ||= get_all
     end
 
-    def api_service
-      # The underlying class from Dogapi that talks to datadog
-      client.instance_variable_get(:@monitor_svc)
-    end
-
     def api_version
       'v1'
     end

--- a/lib/datadog_backup/options.rb
+++ b/lib/datadog_backup/options.rb
@@ -10,20 +10,8 @@ module DatadogBackup
       @options[:backup_dir]
     end
 
-    def client
-      @options[:client]
-    end
-
     def concurrency_limit
       @options[:concurrency_limit] | 2
-    end
-
-    def datadog_api_key
-      @options[:datadog_api_key]
-    end
-
-    def datadog_app_key
-      @options[:datadog_app_key]
     end
 
     def diff_format

--- a/lib/datadog_backup/version.rb
+++ b/lib/datadog_backup/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DatadogBackup
-  VERSION = '2.0.2'
+  VERSION = '3.0.0.alpha.1'
 end

--- a/lib/datadog_backup/version.rb
+++ b/lib/datadog_backup/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DatadogBackup
-  VERSION = '3.0.0.alpha.1'
+  VERSION = '3.0.0.alpha.2'
 end

--- a/spec/datadog_backup/local_filesystem_spec.rb
+++ b/spec/datadog_backup/local_filesystem_spec.rb
@@ -3,12 +3,10 @@
 require 'spec_helper'
 
 describe DatadogBackup::LocalFilesystem do
-  let(:client_double) { double }
   let(:tempdir) { Dir.mktmpdir }
   let(:core) do
     DatadogBackup::Core.new(
       action: 'backup',
-      client: client_double,
       backup_dir: tempdir,
       resources: [DatadogBackup::Dashboards],
       output_format: :json
@@ -17,7 +15,6 @@ describe DatadogBackup::LocalFilesystem do
   let(:core_yaml) do
     DatadogBackup::Core.new(
       action: 'backup',
-      client: client_double,
       backup_dir: tempdir,
       resources: [],
       output_format: :yaml

--- a/spec/datadog_backup_bin_spec.rb
+++ b/spec/datadog_backup_bin_spec.rb
@@ -32,8 +32,8 @@ describe 'bin/datadog_backup' do
   end
 
   required_vars = %w[
-    DATADOG_API_KEY
-    DATADOG_APP_KEY
+    DD_API_KEY
+    DD_APP_KEY
   ]
 
   env = {}
@@ -52,7 +52,7 @@ describe 'bin/datadog_backup' do
   it 'supplies help' do
     stub_const('ENV', env)
     out_err, status = run_bin('--help')
-    expect(out_err).to match(/Usage: DATADOG_API_KEY=/)
+    expect(out_err).to match(/Usage: DD_API_KEY=/)
     expect(status).to be_success
   end
 end

--- a/spec/datadog_backup_bin_spec.rb
+++ b/spec/datadog_backup_bin_spec.rb
@@ -17,13 +17,13 @@ describe 'bin/datadog_backup' do
         i.close
       end
 
-      Timeout.timeout(2.0) do
+      Timeout.timeout(4.0) do
         oe.each do |v|
           output += v
         end
       end
     rescue Timeout::Error
-      LOGGER.warn "Timing out #{t.inspect} after 2 second"
+      LOGGER.error "Timing out #{t.inspect} after 4 second"
       Process.kill(15, pid)
     ensure
       status = t.value

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,8 +4,8 @@ $LOAD_PATH.unshift(File.expand_path('../lib', File.dirname(__FILE__)))
 
 require 'logger'
 $stdout.sync = $stderr.sync = true
-LOGGER = Logger.new('/dev/null')
-LOGGER.level = Logger::INFO
+LOGGER = Logger.new($stderr)
+LOGGER.level = Logger::ERROR
 $stdout = File.new('/dev/null', 'w+')
 
 require 'tmpdir'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,6 @@ LOGGER.level = Logger::INFO
 $stdout = File.new('/dev/null', 'w+')
 
 require 'tmpdir'
-require 'dogapi'
 require 'datadog_backup'
 
 


### PR DESCRIPTION
# v3 Migration

## Breaking Changes
v3 is a backwards incompatible change.

- [ ] DATADOG_API_KEY and DATADOG_APP_KEY are no longer the environment variables used to authenticate to Datadog. Instead, set the environment variables DD_API_KEY and DD_APP_KEY.
- [ ] ruby 2.6 is no longer supported. Please upgrade to ruby 2.7 or higher.
- [ ] The options `--ssh` and `--ssshh` are no longer supported. Instead, please use `--quiet` to supress logging. `--debug` remains supported.
- [ ] The environment variable `DATADOG_HOST` is no longer supported. Instead, please use `DD_SITE_URL`.


## Misc
- [ ] The legacy [dogapi-rb ](https://github.com/DataDog/dogapi-rb) gem is replaced with [faraday](https://lostisland.github.io/faraday/).  The [official client library](https://github.com/DataDog/datadog-api-client-ruby) was considered, but was not adopted as I had a hard time grok-ing it. 