### PR TITLE
refactor: memoize #get_all at core.rb

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    datadog_backup (3.0.0.alpha.2)
+    datadog_backup (3.0.0)
       amazing_print
       concurrent-ruby
       deepsort

--- a/lib/datadog_backup/core.rb
+++ b/lib/datadog_backup/core.rb
@@ -82,10 +82,11 @@ module DatadogBackup
     end
 
     def get_all
+      return @get_all if @get_all
       params = {}
       headers = {}
       response = api_service.get("/api/#{api_version}/#{api_resource_name}", params, headers)
-      body_with_2xx(response)
+      @get_all = body_with_2xx(response)
     end
 
     def get_and_write_file(id)

--- a/lib/datadog_backup/dashboards.rb
+++ b/lib/datadog_backup/dashboards.rb
@@ -3,6 +3,10 @@
 module DatadogBackup
   class Dashboards < Core
 
+    def all_dashboards
+      get_all.fetch('dashboards')
+    end
+
     def api_version
       'v1'
     end
@@ -25,10 +29,6 @@ module DatadogBackup
       watcher.join if watcher.status
 
       Concurrent::Promises.zip(*futures).value!
-    end
-
-    def all_dashboards
-      get_all.fetch('dashboards')
     end
 
     def initialize(options)

--- a/lib/datadog_backup/dashboards.rb
+++ b/lib/datadog_backup/dashboards.rb
@@ -3,10 +3,6 @@
 module DatadogBackup
   class Dashboards < Core
 
-    def all_dashboards
-      get_all.fetch('dashboards')
-    end
-
     def api_version
       'v1'
     end
@@ -18,7 +14,8 @@ module DatadogBackup
     def backup
       LOGGER.info("Starting diffs on #{::DatadogBackup::ThreadPool::TPOOL.max_length} threads")
 
-      futures = all_dashboards.map do |board|
+      dashboards = get_all.fetch('dashboards')
+      futures = dashboards.map do |board|
         Concurrent::Promises.future_on(::DatadogBackup::ThreadPool::TPOOL, board) do |board|
           id = board['id']
           get_and_write_file(id)

--- a/lib/datadog_backup/monitors.rb
+++ b/lib/datadog_backup/monitors.rb
@@ -2,9 +2,6 @@
 
 module DatadogBackup
   class Monitors < Core
-    def all_monitors
-      @all_monitors ||= get_all
-    end
 
     def api_version
       'v1'
@@ -15,14 +12,14 @@ module DatadogBackup
     end
 
     def backup
-      all_monitors.map do |monitor|
+      get_all.map do |monitor|
         id = monitor['id']
         write_file(dump(get_by_id(id)), filename(id))
       end
     end
 
     def get_by_id(id)
-      monitor = all_monitors.select { |monitor| monitor['id'].to_s == id.to_s }.first
+      monitor = get_all.select { |monitor| monitor['id'].to_s == id.to_s }.first
       monitor.nil? ? {} : except(monitor)
     end
 

--- a/spec/datadog_backup/monitors_spec.rb
+++ b/spec/datadog_backup/monitors_spec.rb
@@ -57,8 +57,8 @@ describe DatadogBackup::Monitors do
     stubs.get('/api/v1/dashboard/123455') { example_monitor }
   end
 
-  describe '#all_monitors' do
-    subject { monitors.all_monitors }
+  describe '#get_all' do
+    subject { monitors.get_all }
 
     it { is_expected.to eq [monitor_description] }
   end


### PR DESCRIPTION
Memoize #get_all at the base Core class, so that the specific classes don't have to implement the same protocol. 