### PR TITLE
feat: Deepsort skip sorting arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ parameter            | description                                              
 --no-color           | removes colored output from diff format
 --diff-format FORMAT | one of `color`, `html_simple`, `html`                                                                                         | `color`
 --force-restore      | Force restore to Datadog. Do not ask to validate. Non-interactive.
+--disable-array-sort | Do not sort array elements, to preserver order of dashboard widgets.
 --h, --help          | help
 
 ## Environment variables

--- a/bin/datadog_backup
+++ b/bin/datadog_backup
@@ -66,6 +66,9 @@ def prereqs(defaults) # rubocop:disable Metrics/AbcSize
     opts.on('--force-restore', 'Force restore to Datadog. Do not ask to validate. Non-interactive.') do
       result[:force_restore] = true
     end
+    opts.on('--disable-array-sort', 'Do not sort array elements, to preserver order of dashboard widgets.') do
+      result[:disable_array_sort] = true
+    end
   end
   options.parse!
 
@@ -82,7 +85,8 @@ defaults = {
   diff_format: :color,
   resources: [DatadogBackup::Dashboards, DatadogBackup::Monitors, DatadogBackup::Synthetics],
   output_format: :yaml,
-  force_restore: false
+  force_restore: false,
+  disable_array_sort: false
 }
 
 DatadogBackup::Cli.new(prereqs(defaults)).run!

--- a/lib/datadog_backup/local_filesystem.rb
+++ b/lib/datadog_backup/local_filesystem.rb
@@ -32,9 +32,9 @@ module DatadogBackup
     def dump(object)
       case output_format
       when :json
-        JSON.pretty_generate(object.deep_sort)
+        JSON.pretty_generate(object.deep_sort(array: disable_array_sort ? false : true))
       when :yaml
-        YAML.dump(object.deep_sort)
+        YAML.dump(object.deep_sort(array: disable_array_sort ? false : true))
       else
         raise 'invalid output_format specified or not specified'
       end

--- a/lib/datadog_backup/options.rb
+++ b/lib/datadog_backup/options.rb
@@ -31,5 +31,9 @@ module DatadogBackup
     def force_restore
       @options[:force_restore]
     end
+
+    def disable_array_sort
+      @options[:disable_array_sort]
+    end
   end
 end

--- a/lib/datadog_backup/resources.rb
+++ b/lib/datadog_backup/resources.rb
@@ -26,8 +26,8 @@ module DatadogBackup
     # Returns the diffy diff.
     # Optionally, supply an array of keys to remove from comparison
     def diff(id)
-      current = except(get_by_id(id)).deep_sort.to_yaml
-      filesystem = except(load_from_file_by_id(id)).deep_sort.to_yaml
+      current = except(get_by_id(id)).deep_sort(array: disable_array_sort ? false : true).to_yaml
+      filesystem = except(load_from_file_by_id(id)).deep_sort(array: disable_array_sort ? false : true).to_yaml
       result = ::Diffy::Diff.new(current, filesystem, include_plus_and_minus_in_html: true).to_s(diff_format)
       LOGGER.debug("Compared ID #{id} and found filesystem: #{filesystem} <=> current: #{current} == result: #{result}")
       result.chomp

--- a/spec/datadog_backup/local_filesystem_spec.rb
+++ b/spec/datadog_backup/local_filesystem_spec.rb
@@ -20,6 +20,15 @@ describe DatadogBackup::LocalFilesystem do
       output_format: :yaml
     )
   end
+  let(:resources_disable_array_sort) do
+    DatadogBackup::Resources.new(
+      action: 'backup',
+      backup_dir: tempdir,
+      resources: [DatadogBackup::Dashboards],
+      output_format: :json,
+      disable_array_sort: true
+    )
+  end
 
   describe '#all_files' do
     subject { resources.all_files }
@@ -78,6 +87,18 @@ describe DatadogBackup::LocalFilesystem do
       subject { resources_yaml.dump({ 'a' => 'b' }) }
 
       it { is_expected.to eq(%(---\na: b\n)) }
+    end
+
+    context 'when array sorting is enabled' do
+      subject { resources.dump({ a: [ :c, :b ] }) }
+
+      it { is_expected.to eq(%({\n  \"a\": [\n    \"b\",\n    \"c\"\n  ]\n})) }
+    end
+
+    context 'when array sorting is disabled' do
+      subject { resources_disable_array_sort.dump({ a: [ :c, :b ] }) }
+
+      it { is_expected.to eq(%({\n  \"a\": [\n    \"c\",\n    \"b\"\n  ]\n})) }
     end
   end
 


### PR DESCRIPTION
Add parameter `--disable-array-sort`, that will set array sorting to false for `deepsort`. Solves #146.