### PR TITLE
fix: update error handling for restore

### DIFF
--- a/lib/datadog_backup/dashboards.rb
+++ b/lib/datadog_backup/dashboards.rb
@@ -22,6 +22,15 @@ module DatadogBackup
       Concurrent::Promises.zip(*futures).value!
     end
 
+    def get_by_id(id)
+      begin
+        dashboard = except(get(id))
+      rescue Faraday::ResourceNotFound => e
+        dashboard = {}
+      end
+      except(dashboard)
+    end
+
     def initialize(options)
       super(options)
       @banlist = %w[modified_at url].freeze

--- a/lib/datadog_backup/resources.rb
+++ b/lib/datadog_backup/resources.rb
@@ -110,9 +110,7 @@ module DatadogBackup
       body = load_from_file_by_id(id)
       begin
         update(id, body)
-      rescue RuntimeError => e
-        raise e.message unless e.message.include?('update failed with error 404')
-
+      rescue Faraday::ResourceNotFound => e
         create_newly(id, body)
       end
     end

--- a/spec/datadog_backup/core_spec.rb
+++ b/spec/datadog_backup/core_spec.rb
@@ -103,7 +103,7 @@ describe DatadogBackup::Resources do
       allow(resources).to receive(:api_resource_name).and_return('api-resource-name-string')
       stubs.get('/api/api-version-string/api-resource-name-string/abc-123-def') { respond_with200({ 'test' => 'ok' }) }
       stubs.get('/api/api-version-string/api-resource-name-string/bad-123-id') do
-        [404, {}, { 'error' => 'blahblah_not_found' }]
+        raise Faraday::ResourceNotFound
       end
       allow(resources).to receive(:load_from_file_by_id).and_return({ 'load' => 'ok' })
     end
@@ -126,7 +126,7 @@ describe DatadogBackup::Resources do
       before do
         allow(resources).to receive(:load_from_file_by_id).and_return({ 'load' => 'ok' })
         stubs.put('/api/api-version-string/api-resource-name-string/bad-123-id') do
-          [404, {}, { 'error' => 'id not found' }]
+          raise Faraday::ResourceNotFound
         end
         stubs.post('/api/api-version-string/api-resource-name-string', { 'load' => 'ok' }) do
           respond_with200({ 'id' => 'my-new-id' })

--- a/spec/datadog_backup/synthetics_spec.rb
+++ b/spec/datadog_backup/synthetics_spec.rb
@@ -231,7 +231,7 @@ describe DatadogBackup::Synthetics do
 
       before do
         synthetics.write_file(synthetics.dump({ 'name' => 'restore-invalid-id', 'type' => 'api' }), synthetics.filename('restore-invalid-id'))
-        stubs.put('/api/v1/synthetics/tests/api/restore-invalid-id') { [404, {}, ''] }
+        stubs.put('/api/v1/synthetics/tests/api/restore-invalid-id') { raise Faraday::ResourceNotFound }
         stubs.post('/api/v1/synthetics/tests/api') { respond_with200({ 'public_id' => 'restore-valid-id' }) }
         allow(synthetics).to receive(:create).and_call_original
         allow(synthetics).to receive(:all).and_return([api_test, browser_test, { 'public_id' => 'restore-valid-id', 'type' => 'api' }])


### PR DESCRIPTION
From my testing, farraday is raising `Faraday::ResourceNotFound` errors when a get by ID request can't find a resource. The current `rescue RuntimeError => e` block is not rescuing these errors, which leads to the failure in #148. I'm guessing faraday updated their error raising at some point which caused the existing rescue block to no longer work?

Resolves #148:
- Update the error handling of the `restore` method to use `Faraday::ResourceNotFound`
- Override `get_by_id` for dashboards to add error handling for when a dashboard ID can't be found