### PR TITLE
fix: Deprecate Ruby 3.0 and Drop support for Ruby 2.7

### DIFF
--- a/.github/workflows/rspec_and_release.yml
+++ b/.github/workflows/rspec_and_release.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-        ruby: [2.7, '3.0', '3.1']
+        ruby: ['3.0', '3.1', '3.2']
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Additional features may be built out over time.
 v3 is a backwards incompatible change.
 
 - [ ] DATADOG_API_KEY and DATADOG_APP_KEY are no longer the environment variables used to authenticate to Datadog. Instead, set the environment variables DD_API_KEY and DD_APP_KEY.
-- [ ] ruby 2.6 is no longer supported. Please upgrade to ruby 2.7 or higher.
+- [ ] ruby 2.7 is no longer supported. Please upgrade to ruby 3.0 or higher.
 - [ ] The options `--ssh` and `--ssshh` are no longer supported. Instead, please use `--quiet` to supress logging. `--debug` remains supported.
 - [ ] The environment variable `DATADOG_HOST` is no longer supported. Instead, please use `DD_SITE_URL`.
 

--- a/datadog_backup.gemspec
+++ b/datadog_backup.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.7'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'amazing_print'
   spec.add_dependency 'concurrent-ruby'

--- a/example/.github/workflows/backup.yml
+++ b/example/.github/workflows/backup.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Ruby 2.7.1
+    - uses: actions/checkout@v4
+    - name: Set up Ruby 3.1
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7.1
+        ruby-version: 3.1
     - name: perform backup
       env:
         DD_API_KEY: ${{ secrets.DD_API_KEY }}
@@ -24,7 +24,7 @@ jobs:
           bundle install --jobs 4 --retry 3
           bundle exec datadog_backup backup
     - name: commit changes
-      uses: stefanzweifel/git-auto-commit-action@v4
+      uses: stefanzweifel/git-auto-commit-action@v5
       with:
         commit_message: "Changes as of run: ${{ github.run_id }}"
         file_pattern: backup/

--- a/lib/datadog_backup/deprecations.rb
+++ b/lib/datadog_backup/deprecations.rb
@@ -4,7 +4,7 @@ module DatadogBackup
   # Notify the user if they are using deprecated features.
   module Deprecations
     def self.check
-      LOGGER.warn "ruby-#{RUBY_VERSION} is deprecated. Ruby 2.7 or higher will be required to use this gem after datadog_backup@v3" if RUBY_VERSION < '2.7'
+      LOGGER.warn "ruby-#{RUBY_VERSION} is deprecated. Ruby 3.1 or higher will be required to use this gem after datadog_backup@v3" if RUBY_VERSION < '3.1'
     end
   end
 end

--- a/spec/datadog_backup/deprecations_spec.rb
+++ b/spec/datadog_backup/deprecations_spec.rb
@@ -12,7 +12,7 @@ describe DatadogBackup::Deprecations do
     allow(logger).to receive(:warn)
   end
 
-  %w[2.4.10 2.5.9 2.6.8].each do |ruby_version|
+  %w[2.5.9 2.6.8 2.7 3.0.4].each do |ruby_version|
     describe "#check#{ruby_version}" do
       it 'does warn' do
         stub_const('RUBY_VERSION', ruby_version)
@@ -22,7 +22,7 @@ describe DatadogBackup::Deprecations do
     end
   end
 
-  %w[2.7.4 3.0.4 3.1.2 3.2.0-preview1].each do |ruby_version|
+  %w[3.1.2 3.2.0-preview1].each do |ruby_version|
     describe "#check#{ruby_version}" do
       it 'does not warn' do
         stub_const('RUBY_VERSION', ruby_version)


### PR DESCRIPTION
Ruby 3.0 reached end-of-life on 2024-04-23 ([reference](https://www.ruby-lang.org/en/downloads/branches/))