### PR TITLE
fix: YAML.dump quotes y when dumping

### DIFF
--- a/lib/datadog_backup/local_filesystem.rb
+++ b/lib/datadog_backup/local_filesystem.rb
@@ -34,7 +34,7 @@ module DatadogBackup
       when :json
         JSON.pretty_generate(object.deep_sort(array: disable_array_sort ? false : true))
       when :yaml
-        YAML.dump(object.deep_sort(array: disable_array_sort ? false : true))
+        YAML.dump(object.deep_sort(array: disable_array_sort ? false : true)).gsub('"y":','y:')
       else
         raise 'invalid output_format specified or not specified'
       end


### PR DESCRIPTION
Per https://github.com/ruby/psych/issues/443 we need to manually convert `y` in the dumped file to be consistent with other fields returned from Datadog i.e.
```
irb(main):032> {"layout"=>{"x"=>20, "y"=>6}}.to_yaml
=> "---\nlayout:\n  x: 20\n  \"y\": 6\n"

irb(main):035> {"layout"=>{"x"=>20, "y"=>6}}.to_yaml.gsub('"y":','y:' )
=> "---\nlayout:\n  x: 20\n  y: 6\n"
```