### PR TITLE
fix: Update github actions due to ubuntu-20.04 deprecation

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -7,7 +7,7 @@ on:
       - synchronize
 jobs:
   main:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Validate PR Title
       uses: amannn/action-semantic-pull-request@v5.4.0


### PR DESCRIPTION
Use sourcegraph batch change to update ubuntu-20.04 to ubuntu-22.04.

[_Created by Sourcegraph batch change `kristianmills/actionrunner`._](https://scribd.sourcegraphcloud.com/users/kristianmills/batch-changes/actionrunner)